### PR TITLE
Allow --check and --print to be used together

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ There are three modes cargo-sort can be used in:
     The `key_value_newlines` config option needs to be `true` for this to have any effect.
  * **-p or --print**
     - Write the sorted toml file to stdout.
+ * **-r or --rewrite**
+    - Rewrite the toml file in place if it was unsorted.
  * **-w or --workspace**
     - Checks every crate in the workspace based on flags. Only one root may be given.
  * **-o or --order**

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,11 @@ fn _main() -> IoResult<()> {
     if args.len() > 1 && args[1] == "sort" {
         args.remove(1);
     }
-    let cli = <Cli as clap::Parser>::parse_from(args);
+    let mut cli = <Cli as clap::Parser>::parse_from(args);
+    if !cli.check && !cli.print && !cli.rewrite {
+        // If no option is specified, default to rewrite
+        cli.rewrite = true;
+    }
 
     let cwd = std::env::current_dir()
         .map_err(|e| format!("no current directory found: {e}"))?;


### PR DESCRIPTION
For automated checks in CI, it would be nice to run cargo-sort with `--print` and `--check` at the same time. That way, you can detect failures automatically and also print what the expected output is for easier fixes.

So this PR let's you do that exactly. If you set both `--print` and `--check`, then cargo-sort first prints out the expected output and then checks that the sorted output and the given input match.

This PR also adds a new `--rewrite` flag. This is not necessary for the main feature I care about, but it makes the behavior easier to reason about in my opinion. With this, there is a flag for all 3 actions that cargo-sort can do and you can specify any combination you want.

There is no change in existing behavior:
- No flags specified => rewrite toml files
- `--check` specified => check the toml files and do nothing else
- `--print` specified => print the toml files and do nothing else