### PR TITLE
Add ignore flag to be used with workspace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ There are three modes cargo-sort can be used in:
     - Checks every crate in the workspace based on flags. Only one root may be given.
  * **-o or --order**
     - Specify an ordering of tables. All nested tables will be sorted and appear after the specified table. Any unspecified table will be after specified.
+ * **-i or --ignore**
+    - Specify workspace members to ignore during check or format. The ignored workspace members will be skipped and kept as is. Only works in combination with `-w`.
 
 ### Config
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Finally cargo sort has the --workspace flag and will sort each Cargo.toml file i
 cargo-sort -w/--workspace
 ```
 
+If your workspace contains a Cargo.toml that should not be sorted, for example if it has been automatically generated, it can
+be ignored with the ignore flag:
+```bash
+cargo-sort -w --ignore "workspace-hack" .
+```
+
 These are all valid. File names and extensions can be used on some of the paths but not others, if
 left off the tool will default to Cargo.toml.
 

--- a/mock_workspace/Cargo.toml
+++ b/mock_workspace/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cargo-sort-mock-workspace"
+version = "0.0.1"
+description = "Mock workspace structure used for testing."
+
+[dependencies]
+
+[workspace]
+members = [
+    "mock_cli",
+    "mock_data"
+]

--- a/mock_workspace/mock_cli/Cargo.toml
+++ b/mock_workspace/mock_cli/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "mock-cli"
+version = "0.0.1"
+description = "Mock cli module used for testing."

--- a/mock_workspace/mock_data/Cargo.toml
+++ b/mock_workspace/mock_data/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "mock-data"
+version = "0.0.1"
+description = "Mock data module used for testing."

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,11 @@ fn parse_workspace_member(member: &str, dir: &str) -> IoResult<Vec<String>> {
     }
 }
 
+/// Reads the workspace members, expands any wild cards and excludes members that should not be
+/// processed by `cargo sort`. All members that are either in the `exclude` section of the
+/// workspace section or that are specified in the `ignore` parameter will be removed.
+/// Returns an error if [`parse_workspace_member`] failed to parse a glob pattern in any workspace
+/// member.
 fn parse_and_filter_workspace_members(
     ws: &Table,
     dir: &str,


### PR DESCRIPTION
Sometimes it can be useful to exclude certain modules/`Cargo.toml` files when running `cargo sort` on a complete workspace. For example if you use a `workspace-hack` module. 

This pull requests adds a ignore flag (`-i`/`--ignore`) that can be used in combination with the workspace flag ( `-w`/ `--workspace`) that lets a user specify modules that should be skipped when running `cargo sort`. Example usage:
```bash
cargo sort -w -i "workspace-hack" my_project
```
The ignore flag also supports a list of values and the `?` and `*` glob patterns:
```bash
cargo sort -w -i "workspace-hack","ignore*" my_project
```
