### PR TITLE
Document default table order in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,16 @@ allowed_blank_lines = 1
 crlf = false
 # The user specified ordering of tables in a document.
 # All unspecified tables will come after these.
-table_order = []
+table_order = [
+    "package",
+    "workspace",
+    "lib",
+    "bin",
+    "features",
+    "dependencies",
+    "build-dependencies",
+    "dev-dependencies",
+]
 ```
 
 included in sort check is:


### PR DESCRIPTION
The README currently states that the default value of the `table_order` field in `tomlfmt.toml` is an empty array, yet there is actually a nonempty default value [specified in `src/fmt.rs`](https://github.com/DevinR528/cargo-sort/blob/ac6e328faf467a39e38ab48dc60dcf4f6a46d7a5/src/fmt.rs#L10).  This PR updates the "default" `tomlfmt.toml` in the README to show the actual default.