### PR TITLE
fix workspace discovery & sorting when folder has an extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn write_green<S: Display>(highlight: &str, msg: S) -> IoResult<()> {
 
 fn check_toml(path: &str, cli: &Cli, config: &Config) -> IoResult<bool> {
     let mut path = PathBuf::from(path);
-    if path.extension().is_none() {
+    if path.is_dir() {
         path.push("Cargo.toml");
     }
 
@@ -173,7 +173,7 @@ fn _main() -> IoResult<()> {
     if cli.workspace && is_posible_workspace {
         let dir = filtered_matches[0].to_string();
         let mut path = PathBuf::from(&dir);
-        if path.extension().is_none() {
+        if path.is_dir() {
             path.push("Cargo.toml");
         }
 


### PR DESCRIPTION
When trying to add `cargo sort` to docs.rs, I stumbled onto an odd issue: 

`cargo sort --workspace` just gave me an error: 
```
error: no file found at: /Users/syphar/src/rust-lang/docs.rs/
```

Looking through the source, the culprit seems to be that we're checking for an extension instead of checking if it's a directory before adding a `Cargo.toml` suffix / filename?

Manual testing is good after this change here. 

Are there unittest for this I just didn't see? 

Should we add some? 